### PR TITLE
Update using latest wiki page revision, and more

### DIFF
--- a/TerrariaHappinessCalculator/index.html
+++ b/TerrariaHappinessCalculator/index.html
@@ -104,11 +104,11 @@
                 this.npcs.forEach(npc => {
                     let value = 100.0;
                     
-                    if (this.npcs.length > 3) {
-                        value *= Math.pow(1.05, this.npcs.length - 2);
+                    if (this.npcs.length > 4) {
+                        value *= Math.pow(1.05, this.npcs.length - 3);
                     }
                     
-                    if (this.npcs.length <= 2) {
+                    if (this.npcs.length <= 3) {
                         value *= 0.95;
                     }
                     

--- a/TerrariaHappinessCalculator/index.html
+++ b/TerrariaHappinessCalculator/index.html
@@ -13,7 +13,7 @@
         <span>Terraria NPC Happiness Calculator</span>
         <span class="secondary">by Dodo</span>
         <br/>
-        <span class="secondary" style="font-size: 13px;">Based on data from the <a href="https://terraria.gamepedia.com/NPCs#Happiness">gamepedia</a> accessed on 19.09.2023. Calculator assumes that towns are at least 240 tiles away from each other. Displayed percantages are shop price modifiers, so the lower, the better. Pylons are sold at <span class="happy">90%</span> and below.</span>
+        <span class="secondary" style="font-size: 13px;">Based on data from the <a href="https://terraria.wiki.gg/wiki/NPCs#Happiness">wiki.gg</a> accessed on 19.09.2023. Calculator assumes that towns are at least 240 tiles away from each other. Displayed percantages are shop price modifiers, so the lower, the better. Pylons are sold at <span class="happy">90%</span> and below.</span>
     </div>
     <div id="app"></div>
 </body>

--- a/TerrariaHappinessCalculator/index.html
+++ b/TerrariaHappinessCalculator/index.html
@@ -6,14 +6,14 @@
     <link rel="stylesheet" href="style.css">
     <link rel="icon" href="images/Favicon.ico">
     <title>Terraria NPC Happiness Calculator by Dodo</title>
-    <meta name="Keywords" content="Terraria,NPC,Happiness,Dodo,McjMzn,Journey's End, 1.4.1, Calculator">
+    <meta name="Keywords" content="Terraria,NPC,Happiness,Dodo,McjMzn,Journey's End, 1.4.4.9, Labor of Love, Calculator">
 </head>
 <body>
     <div class="header">
         <span>Terraria NPC Happiness Calculator</span>
         <span class="secondary">by Dodo</span>
         <br/>
-        <span class="secondary" style="font-size: 13px;">Based on data from the <a href="https://terraria.gamepedia.com/NPCs#Happiness">gamepedia</a> accessed on 26.10.2020. Calculator assumes that towns are at least 240 tiles away from each other. Displayed percantages are shop price modifiers, so the lower, the better. Pylons are sold at <span class="happy">85%</span> and below.</span>
+        <span class="secondary" style="font-size: 13px;">Based on data from the <a href="https://terraria.gamepedia.com/NPCs#Happiness">gamepedia</a> accessed on 19.09.2023. Calculator assumes that towns are at least 240 tiles away from each other. Displayed percantages are shop price modifiers, so the lower, the better. Pylons are sold at <span class="happy">90%</span> and below.</span>
     </div>
     <div id="app"></div>
 </body>
@@ -105,21 +105,21 @@
                     let value = 100.0;
                     
                     if (this.npcs.length > 3) {
-                        value *= Math.pow(1.04, this.npcs.length - 2);
+                        value *= Math.pow(1.05, this.npcs.length - 2);
                     }
                     
                     if (this.npcs.length <= 2) {
-                        value *= 0.9;
+                        value *= 0.95;
                     }
                     
                     let townContent = this.biomes.concat(this.npcs.map(n => n.Name));
-                    townContent.filter(c => npc.Loved.includes(c)).forEach(c => value *= 0.9);
-                    townContent.filter(c => npc.Liked.includes(c)).forEach(c => value *= 0.95);
-                    townContent.filter(c => npc.Disliked.includes(c)).forEach(c => value *= 1.05);
-                    townContent.filter(c => npc.Hated.includes(c)).forEach(c => value *= 1.1);
+                    townContent.filter(c => npc.Loved.includes(c)).forEach(c => value *= 0.88);
+                    townContent.filter(c => npc.Liked.includes(c)).forEach(c => value *= 0.94);
+                    townContent.filter(c => npc.Disliked.includes(c)).forEach(c => value *= 1.06);
+                    townContent.filter(c => npc.Hated.includes(c)).forEach(c => value *= 1.2);
                     
-                    let mod = value % 5;
-                    let rounding = mod < 2.5 ? 0 : 5;
+                    let mod = value % 1;
+                    let rounding = mod < 0.5 ? 0 : 1;
                     value = value - mod + rounding;
                     value = value < 75 ? 75 : value;
                     value = value > 150 ? 150 : value; 

--- a/TerrariaHappinessCalculator/model.js
+++ b/TerrariaHappinessCalculator/model.js
@@ -62,7 +62,7 @@ const NpcModels = [
     new NpcBuilder(Npcs.Golfer).loves(Npcs.Angler).likes(Biomes.Forest, Npcs.Painter, Npcs.Zoologist, Npcs.Princess).dislikes(Biomes.Underground, Npcs.Pirate).hates(Npcs.Merchant).build(),
     new NpcBuilder(Npcs.Nurse).loves(Npcs.ArmsDealer).likes(Biomes.Hallow, Npcs.Wizard, Npcs.Princess).dislikes(Biomes.Snow, Npcs.Dryad, Npcs.PartyGirl).hates(Npcs.Zoologist).build(),
     new NpcBuilder(Npcs.Tavernkeep).loves(Npcs.Demolitionist).likes(Biomes.Hallow, Npcs.GoblinTinkerer, Npcs.Princess).dislikes(Biomes.Snow, Npcs.Guide).hates(Npcs.DyeTrader).build(),
-    new NpcBuilder(Npcs.PartyGirl).loves(Npcs.Wizard).likes(Biomes.Hallow, Npcs.Stylist, Npcs.Princess).dislikes(Biomes.Underground, Npcs.Merchant).hates(Npcs.TaxCollector).build(),
+    new NpcBuilder(Npcs.PartyGirl).loves(Npcs.Wizard, Npcs.Zoologist).likes(Biomes.Hallow, Npcs.Stylist, Npcs.Princess).dislikes(Biomes.Underground, Npcs.Merchant).hates(Npcs.TaxCollector).build(),
     new NpcBuilder(Npcs.Wizard).loves(Npcs.Golfer).likes(Biomes.Hallow, Npcs.Merchant, Npcs.Princess).dislikes(Biomes.Ocean, Npcs.WitchDoctor).hates(Npcs.Cyborg).build(),
     new NpcBuilder(Npcs.Demolitionist).loves(Npcs.Tavernkeep).likes(Biomes.Underground, Npcs.Mechanic, Npcs.Princess).dislikes(Biomes.Ocean, Npcs.ArmsDealer, Npcs.GoblinTinkerer).build(),
     new NpcBuilder(Npcs.GoblinTinkerer).loves(Npcs.Mechanic).likes(Biomes.Underground, Npcs.DyeTrader, Npcs.Princess).dislikes(Biomes.Jungle, Npcs.Clothier).hates(Npcs.Stylist).build(),
@@ -70,7 +70,7 @@ const NpcModels = [
     new NpcBuilder(Npcs.DyeTrader).likes(Biomes.Desert, Npcs.ArmsDealer, Npcs.Painter, Npcs.Princess).dislikes(Biomes.Forest, Npcs.Steampunker).hates(Npcs.Pirate).build(),
     new NpcBuilder(Npcs.ArmsDealer).loves(Npcs.Nurse).likes(Biomes.Desert, Npcs.Steampunker, Npcs.Princess).dislikes(Biomes.Snow ,Npcs.Golfer).hates(Npcs.Demolitionist).build(),
     new NpcBuilder(Npcs.Steampunker).loves(Npcs.Cyborg).likes(Biomes.Desert, Npcs.Painter, Npcs.Princess).dislikes(Biomes.Jungle, Npcs.Dryad, Npcs.Wizard, Npcs.PartyGirl).build(),
-    new NpcBuilder(Npcs.Dryad).likes(Biomes.Jungle, Npcs.WitchDoctor, Npcs.Truffle, Npcs.Princess).dislikes(Biomes.Desert, Npcs.Angler, Npcs.Zoologist).hates(Npcs.Golfer).build(),
+    new NpcBuilder(Npcs.Dryad).likes(Biomes.Jungle, Npcs.WitchDoctor, Npcs.Truffle, Npcs.Princess).dislikes(Biomes.Desert, Npcs.Angler).hates(Npcs.Golfer).build(),
     new NpcBuilder(Npcs.Painter).loves(Npcs.Dryad).likes(Biomes.Jungle, Npcs.PartyGirl, Npcs.Princess).dislikes(Biomes.Forest, Npcs.Truffle, Npcs.Cyborg).build(),
     new NpcBuilder(Npcs.WitchDoctor).likes(Biomes.Jungle, Npcs.Dryad, Npcs.Guide, Npcs.Princess).dislikes(Biomes.Hallow, Npcs.Nurse).hates(Npcs.Truffle).build(),
     new NpcBuilder(Npcs.Stylist).loves(Npcs.DyeTrader).likes(Biomes.Ocean, Npcs.Pirate, Npcs.Princess).dislikes(Biomes.Snow, Npcs.Tavernkeep).hates(Npcs.GoblinTinkerer).build(),
@@ -80,6 +80,6 @@ const NpcModels = [
     new NpcBuilder(Npcs.TaxCollector).loves(Npcs.Merchant).likes(Biomes.Snow, Npcs.PartyGirl, Npcs.Princess).dislikes(Biomes.Hallow, Npcs.Demolitionist, Npcs.Mechanic).hates(Npcs.SantaClaus).build(),
     new NpcBuilder(Npcs.Cyborg).likes(Biomes.Snow, Npcs.Steampunker, Npcs.Pirate, Npcs.Stylist, Npcs.Princess).dislikes(Biomes.Jungle, Npcs.Zoologist).hates(Npcs.Wizard).build(),
     new NpcBuilder(Npcs.SantaClaus).likes(Npcs.Princess).loves(Biomes.Snow).hates(Biomes.Desert, Npcs.TaxCollector).build(),
-    new NpcBuilder(Npcs.Truffle).loves(Npcs.Guide).likes(Npcs.Dryad, Npcs.Princess).dislikes(Npcs.Clothier).hates(Npcs.WitchDoctor).build(),
+    new NpcBuilder(Npcs.Truffle).loves(Npcs.Guide).likes(Biomes.Mushroom, Npcs.Dryad, Npcs.Princess).dislikes(Npcs.Clothier).hates(Npcs.WitchDoctor).build(),
     new NpcBuilder(Npcs.Princess).loves(...Object.values(Npcs).filter(npc => npc !== "Princess")).build()
 ].sort((a, b) => a.Name.localeCompare(b.Name));

--- a/TerrariaHappinessCalculator/style.css
+++ b/TerrariaHappinessCalculator/style.css
@@ -45,7 +45,7 @@ a {
 }
 
 .disabled {
-    filter: grayscale(100%)
+    filter: brightness(50%)
 }
 
 .happy {


### PR DESCRIPTION
Changes
- index.html
  - Updated the multipliers for loved/liked/disliked/hated biomes/NPCs, as well as the crowding/solitude penalty/bonus. (changed in 1.4.1)
  - Fixed crowding/solitude bonus NPC count being 1 lower than it should (according to the wiki, the check is looking for how many _other_ NPCs are near the _checked NPC_, so if there are two NPCs nearby the checked NPC, then there are a total of three NPCs in the village including the checked NPC, and still qualifies for the solitude bonus)
  - Updated rounding to nearest 1% instead of nearest 5% (changed in 1.4.1.2)
  - Updated pylon maximum multiplier from 85% to 90% (changed in 1.4.3.3)
  - Updated wiki link to use new official wiki.gg wiki instead of the unofficial wiki formerly hosted by Gamepedia before Fandom took over
- model.js
  - Added Party Girl loves Zoologist
  - Removed Dryad dislikes Zoologist
  - Added Truffle likes Mushroom (changed in 1.4.0.5)
- style.css
  - Changed biome button disabled filter from grayscale to 50% brightness for better colorblind/nighttime-blue-light-filter visibility/accessibility

Remaining issues:
- "If the player is in a hybrid biome, and the NPC loves/likes one of the biomes, but hates/dislikes one of the others, the loved/liked biome will take priority. Biomes that the NPC is neutral to are ignored."
  - Hence, placing the Mechanic in an underground ice biome should give her the liked biome multiplier (ice), but not the disliked biome multiplier (underground). Currently, she will incorrectly receive both.
  - This change was made in 1.4.3.3.
- There's no special code to handle the Princess's multiplier being set to 1000% when with fewer than 2 other NPCs